### PR TITLE
refactor: unify charging color modes for v22

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,7 +5,7 @@
 > **VISUAL POLISH & CODE QUALITY**
 
 - **Stock Icon Mode**: Added a new preference to use the native GNOME battery icon instead of the custom bar or circular indicator.
-- **Charging Color Tuning**: Colored mode now falls back to the theme foreground while charging, avoiding misleading low-battery red/orange states.
+- ~~**Charging Color Tuning**: Colored mode now falls back to the theme foreground while charging, avoiding misleading low-battery red/orange states.~~
 - **Panel Sync**: The stock icon path now respects the same panel visibility flow as the custom indicators.
 - **Version Art**: Added a dedicated `v22` SVG concept icon under `assets/`.
 - **Text Stroke Setting**: Added a global "Text Stroke" preference that toggles a dark outline around percentage text and the charging bolt SVG across all indicator modes (bar, landscape, circular).
@@ -13,6 +13,10 @@
 - **Circular Font Size**: Increased `CIRCLE.FONT_SIZE_RATIO` from 0.42 to 0.5 for better legibility at typical panel sizes (e.g., 37px diameter).
 - **Bolt Stroke Fix**: Fixed bolt SVG stroke not respecting the textStroke toggle in circular mode (with text displayed), ensuring stroke is disabled consistently when the setting is off.
 - **Preferences Cleanup**: Added `close-request` handler to destroy `Gtk.ListBox` and `Adw.ToastOverlay` objects when the preferences window closes, fixing EGO-L-006 warning.
+- **Charging Color Refactor**: Removed the invalid implicit charging fallback and restored `Gradient` as the default color logic for both charging and discharging.
+- **Explicit Charging Overrides**: Added `Charging Icon Color` and `Charging Text Color` modes with explicit `Gradient`, `Theme Foreground`, and `Custom Color` behavior.
+- **Defaults Update**: `Color Gradient Icon` and `Color Gradient Text` now default to `true`.
+- **Preferences Polish**: Cleaned up inconsistent preferences icons and replaced invalid symbolic icon names with working ones.
 
 ## v21 (2026-01-29) - PREFERENCES & LOGGING REFINEMENTS
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -28,7 +28,7 @@
 <!-- LINT-RESULT-START -->
 ### Linting Status
 > **Status**: ✅ **Passing**  
-> **Last Updated**: 2026-04-17 13:58:22 UTC  
+> **Last Updated**: 2026-04-17 14:51:09 UTC  
 > **Summary**: 0 errors, 0 warnings
 
 <details>

--- a/.github/README.md
+++ b/.github/README.md
@@ -26,7 +26,7 @@
 <!-- LINT-RESULT-START -->
 ### Linting Status
 > **Status**: ✅ **Passing**  
-> **Last Updated**: 2026-04-17 19:50:14 UTC  
+> **Last Updated**: 2026-04-17 19:51:44 UTC  
 > **Summary**: 0 errors, 0 warnings
 
 <details>

--- a/.github/README.md
+++ b/.github/README.md
@@ -2,9 +2,7 @@
 
 [![Extension CI](https://github.com/DarkPhilosophy/batt-watt-power-monitor/actions/workflows/ci.yml/badge.svg)](https://github.com/DarkPhilosophy/batt-watt-power-monitor/actions/workflows/ci.yml)
 ![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/DarkPhilosophy/batt-watt-power-monitor?utm_source=oss&utm_medium=github&utm_campaign=DarkPhilosophy%2Fbatt-watt-power-monitor&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)
-[![GNOME Extensions](https://img.shields.io/badge/GNOME-Extensions-orange.svg)](https://extensions.gnome.org/extension/9023/battery-power-monitor/) <!-- GNOME-SHELL-VERSIONS-START -->
-[![GNOME 45-50](https://img.shields.io/badge/GNOME-45--50-blue.svg)](https://www.gnome.org/)
-<!-- GNOME-SHELL-VERSIONS-END -->
+[![GNOME Extensions](https://img.shields.io/badge/GNOME-Extensions-orange.svg)](https://extensions.gnome.org/extension/9023/battery-power-monitor/) <!-- GNOME-SHELL-VERSIONS-START --> [![GNOME 45-50](https://img.shields.io/badge/GNOME-45--50-blue.svg)](https://www.gnome.org/) <!-- GNOME-SHELL-VERSIONS-END -->
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 
 **Battery Power Monitor** - A GNOME Shell extension showing battery percentage, time remaining, and real-time power consumption.
@@ -28,15 +26,15 @@
 <!-- LINT-RESULT-START -->
 ### Linting Status
 > **Status**: ✅ **Passing**  
-> **Last Updated**: 2026-04-17 14:51:09 UTC  
+> **Last Updated**: 2026-04-17 19:50:14 UTC  
 > **Summary**: 0 errors, 0 warnings
 
 <details>
 <summary>Click to view full lint output</summary>
 
 ```text
-> batt-watt-power-monitor@22.0.0 lint
-> eslint extension .scripts --format stylish || true; echo LINT_DONE
+> batt-watt-power-monitor@22.0.0 lint:fix
+> eslint --fix extension .scripts --format stylish || true; echo LINT_DONE
 
 LINT_DONE
 ```

--- a/.github/README.md
+++ b/.github/README.md
@@ -2,7 +2,9 @@
 
 [![Extension CI](https://github.com/DarkPhilosophy/batt-watt-power-monitor/actions/workflows/ci.yml/badge.svg)](https://github.com/DarkPhilosophy/batt-watt-power-monitor/actions/workflows/ci.yml)
 ![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/DarkPhilosophy/batt-watt-power-monitor?utm_source=oss&utm_medium=github&utm_campaign=DarkPhilosophy%2Fbatt-watt-power-monitor&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)
-[![GNOME Extensions](https://img.shields.io/badge/GNOME-Extensions-orange.svg)](https://extensions.gnome.org/extension/9023/battery-power-monitor/) <!-- GNOME-SHELL-VERSIONS-START --> [![GNOME 45-50](https://img.shields.io/badge/GNOME-45--50-blue.svg)](https://www.gnome.org/) <!-- GNOME-SHELL-VERSIONS-END -->
+[![GNOME Extensions](https://img.shields.io/badge/GNOME-Extensions-orange.svg)](https://extensions.gnome.org/extension/9023/battery-power-monitor/) <!-- GNOME-SHELL-VERSIONS-START -->
+[![GNOME 45-50](https://img.shields.io/badge/GNOME-45--50-blue.svg)](https://www.gnome.org/)
+<!-- GNOME-SHELL-VERSIONS-END -->
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 
 **Battery Power Monitor** - A GNOME Shell extension showing battery percentage, time remaining, and real-time power consumption.
@@ -26,15 +28,15 @@
 <!-- LINT-RESULT-START -->
 ### Linting Status
 > **Status**: ✅ **Passing**  
-> **Last Updated**: 2026-04-15 17:41:09 UTC  
+> **Last Updated**: 2026-04-17 13:58:22 UTC  
 > **Summary**: 0 errors, 0 warnings
 
 <details>
 <summary>Click to view full lint output</summary>
 
 ```text
-> batt-watt-power-monitor@22.0.0 lint:fix
-> eslint --fix extension .scripts --format stylish || true; echo LINT_DONE
+> batt-watt-power-monitor@22.0.0 lint
+> eslint extension .scripts --format stylish || true; echo LINT_DONE
 
 LINT_DONE
 ```
@@ -47,7 +49,7 @@ LINT_DONE
 <summary><strong>Latest Update (v22)</strong></summary>
 
 - **Stock Icon Mode**: Added a new preference to use the native GNOME battery icon instead of the custom bar or circular indicator.
-- **Charging Color Tuning**: Colored mode now falls back to the theme foreground while charging, avoiding misleading low-battery red/orange states.
+- ~~**Charging Color Tuning**: Colored mode now falls back to the theme foreground while charging, avoiding misleading low-battery red/orange states.~~
 - **Panel Sync**: The stock icon path now respects the same panel visibility flow as the custom indicators.
 - **Version Art**: Added a dedicated `v22` SVG concept icon under `assets/`.
 - **Text Stroke Setting**: Added a global "Text Stroke" preference that toggles a dark outline around percentage text and the charging bolt SVG across all indicator modes (bar, landscape, circular).
@@ -55,6 +57,10 @@ LINT_DONE
 - **Circular Font Size**: Increased `CIRCLE.FONT_SIZE_RATIO` from 0.42 to 0.5 for better legibility at typical panel sizes (e.g., 37px diameter).
 - **Bolt Stroke Fix**: Fixed bolt SVG stroke not respecting the textStroke toggle in circular mode (with text displayed), ensuring stroke is disabled consistently when the setting is off.
 - **Preferences Cleanup**: Added `close-request` handler to destroy `Gtk.ListBox` and `Adw.ToastOverlay` objects when the preferences window closes, fixing EGO-L-006 warning.
+- **Charging Color Refactor**: Removed the invalid implicit charging fallback and restored `Gradient` as the default color logic for both charging and discharging.
+- **Explicit Charging Overrides**: Added `Charging Icon Color` and `Charging Text Color` modes with explicit `Gradient`, `Theme Foreground`, and `Custom Color` behavior.
+- **Defaults Update**: `Color Gradient Icon` and `Color Gradient Text` now default to `true`.
+- **Preferences Polish**: Cleaned up inconsistent preferences icons and replaced invalid symbolic icon names with working ones.
 
 </details>
 <!-- LATEST-VERSION-END -->
@@ -74,7 +80,12 @@ LINT_DONE
 | **Show Icon** | `true` | Toggle the panel icon. |
 | **Use Circular Indicator** | `false` | Replace battery icon with a circular meter. |
 | **Use GNOME Stock Icon** | `false` | Use the stock GNOME battery icon instead of custom indicators. |
-| **Show Colored** | `false` | Enable colored ring/text. Disable for monochrome. |
+| **Color Gradient Icon** | `true` | Enable the red-to-green gradient for the icon. Disable for themed monochrome. |
+| **Charging Icon Color** | `gradient` | Charging override for the icon: `gradient`, `theme`, or `custom`. |
+| **Custom Charging Icon Color** | `#ffffff` | Custom icon color used only when charging icon mode is `custom`. |
+| **Color Gradient Text** | `true` | Enable the red-to-green gradient for text. Disable for themed monochrome. |
+| **Charging Text Color** | `gradient` | Charging override for text: `gradient`, `theme`, or `custom`. |
+| **Custom Charging Text Color** | `#ffffff` | Custom text color used only when charging text mode is `custom`. |
 | **Text Stroke** | `true` | Draw a dark outline around text and the charging bolt. |
 | **Show Percentage** | `true` | Show battery percentage text. |
 | **Percentage Outside** | `false` | Show percentage text adjacent to the icon. |

--- a/.lint-output.txt
+++ b/.lint-output.txt
@@ -1,5 +1,5 @@
 
-> batt-watt-power-monitor@22.0.0 lint
-> eslint extension .scripts --format stylish || true; echo LINT_DONE
+> batt-watt-power-monitor@22.0.0 lint:fix
+> eslint --fix extension .scripts --format stylish || true; echo LINT_DONE
 
 LINT_DONE

--- a/.lint-output.txt
+++ b/.lint-output.txt
@@ -1,5 +1,5 @@
 
-> batt-watt-power-monitor@22.0.0 lint:fix
-> eslint --fix extension .scripts --format stylish || true; echo LINT_DONE
+> batt-watt-power-monitor@22.0.0 lint
+> eslint extension .scripts --format stylish || true; echo LINT_DONE
 
 LINT_DONE

--- a/extension/library/indicators/battery.js
+++ b/extension/library/indicators/battery.js
@@ -14,7 +14,7 @@ import {
     drawTextStroke,
     drawBoltStroke,
 } from '../drawing.js';
-import { getBatteryWidth, getBatteryHeight, buildIndicatorStatus } from '../settings.js';
+import { getBatteryWidth, getBatteryHeight, buildIndicatorStatus, getSettingsSnapshot } from '../settings.js';
 
 const BatteryIndicator = GObject.registerClass(
     class BatteryIndicator extends St.DrawingArea {
@@ -269,12 +269,15 @@ export function ensureBatteryIndicator(settings, extensionPath) {
     if (batteryIndicator) {
         const desiredWidth = getBatteryWidth(settings);
         const desiredHeight = getBatteryHeight(settings);
+        const snapshot = getSettingsSnapshot(settings);
         applyWidgetSize(batteryIndicator, desiredWidth, desiredHeight);
         batteryIndicator.update({
             percentage: batteryIndicator._status?.percentage ?? 0,
             isCharging: batteryIndicator._status?.isCharging ?? false,
             showText: batteryIndicator._status?.showText ?? false,
             useColor: batteryIndicator._status?.useColor ?? false,
+            chargingColorSource: snapshot.chargingIconColorSource,
+            chargingCustomColor: snapshot.chargingCustomColor,
             extensionPath: batteryIndicator._extensionPath,
             width: desiredWidth,
             height: desiredHeight,

--- a/extension/library/indicators/battery.js
+++ b/extension/library/indicators/battery.js
@@ -42,7 +42,14 @@ const BatteryIndicator = GObject.registerClass(
         }
 
         _calculateColor() {
-            return getIndicatorRgb(this, this._status.percentage, this._status.useColor, this._status.useChargingColor);
+            return getIndicatorRgb(
+                this,
+                this._status.percentage,
+                this._status.useColor,
+                this._status.isCharging,
+                this._status.chargingColorSource,
+                this._status.chargingCustomColor,
+            );
         }
 
         _onRepaint(area) {
@@ -322,8 +329,18 @@ export function ensureBatteryIndicator(settings, extensionPath) {
 export function updateBatteryIndicatorStatus(proxy, settings) {
     if (!batteryIndicatorEnabled(settings) || !batteryIndicator || !proxy) return;
 
-    const { percentage, state, isCharging, useChargingColor, showBolt, showText, useColor, textStroke, forceBolt } =
-        buildIndicatorStatus(proxy, settings);
+    const {
+        percentage,
+        state,
+        isCharging,
+        showBolt,
+        showText,
+        useColor,
+        chargingColorSource,
+        chargingCustomColor,
+        textStroke,
+        forceBolt,
+    } = buildIndicatorStatus(proxy, settings);
     Logger.debug(`Bar status: state=${proxy.State} status=${state} charging=${isCharging} pct=${percentage}`);
 
     const batteryW = getBatteryWidth(settings);
@@ -337,7 +354,8 @@ export function updateBatteryIndicatorStatus(proxy, settings) {
         showText,
         textStroke,
         isCharging,
-        useChargingColor,
+        chargingColorSource,
+        chargingCustomColor,
         showBolt,
         forceBolt,
         width: desiredWidth,

--- a/extension/library/indicators/circle.js
+++ b/extension/library/indicators/circle.js
@@ -29,7 +29,14 @@ const CircleIndicator = GObject.registerClass(
         }
 
         _calculateColor() {
-            return getIndicatorRgb(this, this._status.percentage, this._status.useColor, this._status.useChargingColor);
+            return getIndicatorRgb(
+                this,
+                this._status.percentage,
+                this._status.useColor,
+                this._status.isCharging,
+                this._status.chargingColorSource,
+                this._status.chargingCustomColor,
+            );
         }
 
         _drawChargingIcon(context, centerX, centerY, textExtents, red, green, blue) {
@@ -369,10 +376,11 @@ export function updateCircleIndicatorStatus(proxy, settings) {
         percentage,
         state,
         isCharging,
-        useChargingColor,
         showBolt,
         showText,
         useColor,
+        chargingColorSource,
+        chargingCustomColor,
         textStroke,
         forceBolt,
         hideCharging,
@@ -384,10 +392,11 @@ export function updateCircleIndicatorStatus(proxy, settings) {
         percentage,
         state,
         isCharging,
-        useChargingColor,
         showBolt,
         showText,
         useColor,
+        chargingColorSource,
+        chargingCustomColor,
         textStroke,
         forceBolt,
         hideCharging,

--- a/extension/library/indicators/landscape.js
+++ b/extension/library/indicators/landscape.js
@@ -42,7 +42,14 @@ const LandscapeIndicator = GObject.registerClass(
         }
 
         _calculateColor() {
-            return getIndicatorRgb(this, this._status.percentage, this._status.useColor, this._status.useChargingColor);
+            return getIndicatorRgb(
+                this,
+                this._status.percentage,
+                this._status.useColor,
+                this._status.isCharging,
+                this._status.chargingColorSource,
+                this._status.chargingCustomColor,
+            );
         }
 
         _onRepaint(area) {
@@ -317,8 +324,18 @@ export function ensureLandscapeIndicator(settings, extensionPath) {
 export function updateLandscapeIndicatorStatus(proxy, settings) {
     if (!landscapeIndicatorEnabled(settings) || !landscapeIndicator || !proxy) return;
 
-    const { percentage, state, isCharging, useChargingColor, showBolt, showText, useColor, textStroke, forceBolt } =
-        buildIndicatorStatus(proxy, settings);
+    const {
+        percentage,
+        state,
+        isCharging,
+        showBolt,
+        showText,
+        useColor,
+        chargingColorSource,
+        chargingCustomColor,
+        textStroke,
+        forceBolt,
+    } = buildIndicatorStatus(proxy, settings);
     Logger.debug(`Landscape status: state=${proxy.State} status=${state} charging=${isCharging} pct=${percentage}`);
 
     const batteryW = getBatteryWidth(settings);
@@ -332,7 +349,8 @@ export function updateLandscapeIndicatorStatus(proxy, settings) {
         showText,
         textStroke,
         isCharging,
-        useChargingColor,
+        chargingColorSource,
+        chargingCustomColor,
         showBolt,
         forceBolt,
         width: desiredWidth,

--- a/extension/library/indicators/landscape.js
+++ b/extension/library/indicators/landscape.js
@@ -14,7 +14,7 @@ import {
     drawTextStroke,
     drawBoltStroke,
 } from '../drawing.js';
-import { getBatteryWidth, getBatteryHeight, buildIndicatorStatus } from '../settings.js';
+import { getBatteryWidth, getBatteryHeight, buildIndicatorStatus, getSettingsSnapshot } from '../settings.js';
 
 const LandscapeIndicator = GObject.registerClass(
     class LandscapeIndicator extends St.DrawingArea {
@@ -264,12 +264,15 @@ export function ensureLandscapeIndicator(settings, extensionPath) {
     if (landscapeIndicator) {
         const desiredWidth = getBatteryWidth(settings);
         const desiredHeight = getBatteryHeight(settings);
+        const snapshot = getSettingsSnapshot(settings);
         applyWidgetSize(landscapeIndicator, desiredWidth, desiredHeight);
         landscapeIndicator.update({
             percentage: landscapeIndicator._status?.percentage ?? 0,
             isCharging: landscapeIndicator._status?.isCharging ?? false,
             showText: landscapeIndicator._status?.showText ?? false,
             useColor: landscapeIndicator._status?.useColor ?? false,
+            chargingColorSource: snapshot.chargingIconColorSource,
+            chargingCustomColor: snapshot.chargingCustomColor,
             extensionPath: landscapeIndicator._extensionPath,
             width: desiredWidth,
             height: desiredHeight,

--- a/extension/library/label.js
+++ b/extension/library/label.js
@@ -128,7 +128,7 @@ export function updateLabel(proxy, settings) {
 
         powerToggle._percentageLabel.set_text(labelText);
         powerToggle._percentageLabel.visible = showLabel;
-        powerToggle._percentageLabel.set_style(style);
+        powerToggle._percentageLabel.set_style(style || null);
     }
 }
 

--- a/extension/library/label.js
+++ b/extension/library/label.js
@@ -1,7 +1,7 @@
 import { panel } from 'resource:///org/gnome/shell/ui/main.js';
 import * as Logger from './logger.js';
 import { formatTimeRemaining, formatWatts, getLabelStyleFromPercentage } from './utils.js';
-import { getSettingsSnapshot } from './settings.js';
+import { getSettingsSnapshot, getEffectiveBatteryValues } from './settings.js';
 import { getPower } from './upower.js';
 
 let _originalLabelStyle = null;
@@ -44,8 +44,7 @@ export function updateLabel(proxy, settings) {
     const parts = [];
 
     // Handle properties
-    const pct = proxy.percentage ?? proxy.Percentage;
-    const state = proxy.state ?? proxy.State;
+    const { percentage: pct, state } = getEffectiveBatteryValues(proxy, settings);
     const timeEmpty = proxy.time_to_empty ?? proxy.TimeToEmpty;
     const timeFull = proxy.time_to_full ?? proxy.TimeToFull;
     const energyRate = proxy.energy_rate ?? proxy.EnergyRate; // Watts
@@ -91,7 +90,13 @@ export function updateLabel(proxy, settings) {
 
     const labelText = parts.join(' ');
     const showLabel = parts.length > 0;
-    const style = getLabelStyleFromPercentage(pct, snapshot.showColored, state === 1);
+    const style = getLabelStyleFromPercentage(
+        pct,
+        snapshot.showColoredText,
+        state === 1,
+        snapshot.textColorSource,
+        snapshot.textCustomColor,
+    );
 
     Logger.debug(`Label Update: text="${labelText}" visible=${showLabel}`);
 
@@ -123,7 +128,7 @@ export function updateLabel(proxy, settings) {
 
         powerToggle._percentageLabel.set_text(labelText);
         powerToggle._percentageLabel.visible = showLabel;
-        if (style) powerToggle._percentageLabel.set_style(style);
+        powerToggle._percentageLabel.set_style(style);
     }
 }
 

--- a/extension/library/settings.js
+++ b/extension/library/settings.js
@@ -109,7 +109,7 @@ export function getSettingsSnapshot(settings) {
     const showColoredIcon = settings.get_boolean('showcolored');
     const showColoredText = settings.get_boolean('showcoloredtext');
     const chargingIconColorSource = settings.get_string('charging-icon-color-source');
-    const chargingTextColorSource = settings.get_string('text-color-source');
+    const textColorSource = settings.get_string('charging-text-color-source');
     const textStroke = settings.get_boolean('textstroke');
     const forceBolt = settings.get_boolean('forcebolt');
     const hideCharging = settings.get_boolean('hidecharging');
@@ -127,9 +127,9 @@ export function getSettingsSnapshot(settings) {
         showColoredIcon,
         showColoredText,
         chargingIconColorSource,
-        iconCustomColor: settings.get_string('icon-custom-color'),
-        textColorSource: chargingTextColorSource,
-        textCustomColor: settings.get_string('text-custom-color'),
+        chargingCustomColor: settings.get_string('charging-icon-custom-color'),
+        textColorSource,
+        textCustomColor: settings.get_string('charging-text-custom-color'),
         textStroke,
         fakeCharging: settings.get_boolean('debug') && settings.get_boolean('fakecharging'),
         fakeDischarging: settings.get_boolean('debug') && settings.get_boolean('fakedischarging'),
@@ -163,7 +163,7 @@ export function buildIndicatorStatus(proxy, settings) {
         showText: snapshot.showText,
         useColor: snapshot.showColoredIcon,
         chargingColorSource: snapshot.chargingIconColorSource,
-        chargingCustomColor: snapshot.iconCustomColor,
+        chargingCustomColor: snapshot.chargingCustomColor,
         textStroke: snapshot.textStroke,
         forceBolt: snapshot.forceBolt,
         hideCharging: snapshot.hideCharging,

--- a/extension/library/settings.js
+++ b/extension/library/settings.js
@@ -106,7 +106,10 @@ export function getSettingsSnapshot(settings) {
     const showWatts = settings.get_boolean('showwatts');
     const showIcon = settings.get_boolean('showicon');
     const showCircle = settings.get_boolean('usecircleindicator') && !useStockIcon;
-    const showColored = settings.get_boolean('showcolored');
+    const showColoredIcon = settings.get_boolean('showcolored');
+    const showColoredText = settings.get_boolean('showcoloredtext');
+    const chargingIconColorSource = settings.get_string('charging-icon-color-source');
+    const chargingTextColorSource = settings.get_string('text-color-source');
     const textStroke = settings.get_boolean('textstroke');
     const forceBolt = settings.get_boolean('forcebolt');
     const hideCharging = settings.get_boolean('hidecharging');
@@ -121,7 +124,12 @@ export function getSettingsSnapshot(settings) {
         showIcon,
         showCircle,
         useStockIcon,
-        showColored,
+        showColoredIcon,
+        showColoredText,
+        chargingIconColorSource,
+        iconCustomColor: settings.get_string('icon-custom-color'),
+        textColorSource: chargingTextColorSource,
+        textCustomColor: settings.get_string('text-custom-color'),
         textStroke,
         fakeCharging: settings.get_boolean('debug') && settings.get_boolean('fakecharging'),
         fakeDischarging: settings.get_boolean('debug') && settings.get_boolean('fakedischarging'),
@@ -150,11 +158,12 @@ export function buildIndicatorStatus(proxy, settings) {
         percentage,
         state,
         isCharging: fakeCharging || realCharging,
-        useChargingColor: fakeCharging || realCharging,
         showBolt: snapshot.forceBolt || fakeCharging || realCharging,
         fakeDischarging,
         showText: snapshot.showText,
-        useColor: snapshot.showColored,
+        useColor: snapshot.showColoredIcon,
+        chargingColorSource: snapshot.chargingIconColorSource,
+        chargingCustomColor: snapshot.iconCustomColor,
         textStroke: snapshot.textStroke,
         forceBolt: snapshot.forceBolt,
         hideCharging: snapshot.hideCharging,

--- a/extension/library/sync.js
+++ b/extension/library/sync.js
@@ -227,8 +227,10 @@ export function enableSyncOverride(settings) {
         const effective = getEffectiveBatteryValues(this._proxy ?? powerToggle?._proxy, settings);
         const labelStyle = getLabelStyleFromPercentage(
             effective.percentage,
-            settings.get_boolean('showcolored'),
+            snapshot.showColoredText,
             effective.state === UPower.DeviceState.CHARGING,
+            snapshot.textColorSource,
+            snapshot.textCustomColor,
         );
 
         // Removed local targeting logic as it was flaky.

--- a/extension/library/utils.js
+++ b/extension/library/utils.js
@@ -171,7 +171,7 @@ export function getLabelStyleFromPercentage(
     percentage,
     useColor,
     isCharging = false,
-    chargingColorSource = 'theme',
+    chargingColorSource = 'gradient',
     chargingCustomColor = '#ffffff',
 ) {
     if (!useColor) return 'color: var(--theme-fg-color);';

--- a/extension/library/utils.js
+++ b/extension/library/utils.js
@@ -100,6 +100,45 @@ function rgbToHex(rgb) {
 }
 
 /**
+ * Normalize a CSS hex color string.
+ *
+ * @param {string} value - Raw color value.
+ * @param {string} fallback - Fallback hex color.
+ * @returns {string} Normalized #rrggbb color.
+ */
+function normalizeHexColor(value, fallback = '#ffffff') {
+    const trimmed = String(value ?? '').trim();
+    const expanded = trimmed.match(/^#?([0-9a-fA-F]{3})$/u);
+    if (expanded) {
+        return `#${expanded[1]
+            .split('')
+            .map(channel => channel + channel)
+            .join('')
+            .toLowerCase()}`;
+    }
+
+    const full = trimmed.match(/^#?([0-9a-fA-F]{6})$/u);
+    if (full) return `#${full[1].toLowerCase()}`;
+    return fallback;
+}
+
+/**
+ * Resolve an explicit color mode to CSS text color.
+ *
+ * @param {number} percentage - Battery percentage.
+ * @param {string} colorSource - gradient|theme|custom
+ * @param {string} customColor - Custom color string.
+ * @returns {string} CSS color declaration.
+ */
+function resolveTextStyle(percentage, colorSource, customColor) {
+    if (colorSource === 'custom') return `color: ${normalizeHexColor(customColor)};`;
+    if (colorSource === 'theme') return 'color: var(--theme-fg-color);';
+
+    const rgb = getGradientRGB(percentage);
+    return `color: ${rgbToHex(rgb)};`;
+}
+
+/**
  * Get color values (0-1) for a given percentage using a Red->Green gradient.
  *
  * @param {number} percentage - Battery percentage (0-100)
@@ -123,16 +162,20 @@ function getGradientRGB(percentage) {
  *
  * @param {number} percentage - Battery percentage.
  * @param {boolean} useColor - Whether to apply color.
- * @param {boolean} _isCharging - When true, use theme foreground instead of gradient.
+ * @param {boolean} isCharging - Whether the device is charging.
+ * @param {string} chargingColorSource - Charging text color source.
+ * @param {string} chargingCustomColor - Custom charging text color.
  * @returns {string|null} CSS string or null.
  */
-export function getLabelStyleFromPercentage(percentage, useColor, _isCharging = false) {
-    if (!useColor) return null;
-    if (_isCharging) {
-        return 'color: var(--theme-fg-color);';
-    }
-    const rgb = getGradientRGB(percentage);
-    return `color: ${rgbToHex(rgb)};`;
+export function getLabelStyleFromPercentage(
+    percentage,
+    useColor,
+    isCharging = false,
+    chargingColorSource = 'theme',
+    chargingCustomColor = '#ffffff',
+) {
+    if (!useColor) return 'color: var(--theme-fg-color);';
+    return resolveTextStyle(percentage, isCharging ? chargingColorSource : 'gradient', chargingCustomColor);
 }
 
 /**
@@ -166,13 +209,37 @@ export function getRingColor(percentage) {
  * @param {object} actor - St widget
  * @param {number} percentage - Battery percentage
  * @param {boolean} useColor - Whether colored mode is enabled
- * @param {boolean} _isCharging - Unused. Kept for call-site compatibility.
+ * @param {boolean} isCharging - Whether the device is charging.
+ * @param {string} chargingColorSource - gradient|theme|custom charging override.
+ * @param {string} chargingCustomColor - Custom color for charging override.
  * @returns {Array<number>} [r, g, b]
  */
-export function getIndicatorRgb(actor, percentage, useColor, _isCharging) {
+export function getIndicatorRgb(
+    actor,
+    percentage,
+    useColor,
+    isCharging,
+    chargingColorSource = 'gradient',
+    chargingCustomColor,
+) {
     if (!useColor) {
         const fg = getForegroundColor(actor);
         return [fg.red / 255, fg.green / 255, fg.blue / 255];
+    }
+
+    if (isCharging) {
+        if (chargingColorSource === 'custom') {
+            const color = normalizeHexColor(chargingCustomColor);
+            const red = Number.parseInt(color.slice(1, 3), 16) / 255;
+            const green = Number.parseInt(color.slice(3, 5), 16) / 255;
+            const blue = Number.parseInt(color.slice(5, 7), 16) / 255;
+            return [red, green, blue];
+        }
+
+        if (chargingColorSource === 'theme') {
+            const fg = getForegroundColor(actor);
+            return [fg.red / 255, fg.green / 255, fg.blue / 255];
+        }
     }
 
     return getGradientRGB(percentage);

--- a/extension/prefs.js
+++ b/extension/prefs.js
@@ -8,7 +8,7 @@ import GLib from 'gi://GLib';
 
 import { ExtensionPreferences, gettext as _ } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
-const BUILD_DATE = '2026-04-17T13:58:16.559Z';
+const BUILD_DATE = '2026-04-17T14:51:07.800Z';
 const CHANGELOG = `
 TEXT STROKE, DRY REFACTOR & CIRCULAR FONT REFRESH
 
@@ -418,6 +418,9 @@ export default class BattConsumptionPreferences extends ExtensionPreferences {
             dropDown.connect('notify::selected', widget => {
                 settings.set_string(settingKey, colorModeValues[widget.get_selected()] ?? 'gradient');
             });
+            settings.connect(`changed::${settingKey}`, () => {
+                dropDown.set_selected(colorModeMap[settings.get_string(settingKey)] ?? 0);
+            });
             return dropDown;
         };
         const makeColorButton = (settingKey, title) => {
@@ -466,8 +469,8 @@ export default class BattConsumptionPreferences extends ExtensionPreferences {
             title: _('Custom Charging Icon Color'),
             subtitle: _('Used only when Charging Icon Color is set to Custom'),
         });
-        addIcon(customIconColorRow, 'battery-full-charging-symbolic');
-        const customIconColorButton = makeColorButton('icon-custom-color', _('Select Charging Icon Color'));
+        addIcon(customIconColorRow, 'color-select-symbolic');
+        const customIconColorButton = makeColorButton('charging-icon-custom-color', _('Select Charging Icon Color'));
         customIconColorRow.add_suffix(customIconColorButton);
         styleGroup.add(customIconColorRow);
 
@@ -489,7 +492,7 @@ export default class BattConsumptionPreferences extends ExtensionPreferences {
             subtitle: _('Choose the color used by text while the battery is charging'),
         });
         addIcon(textColorSourceRow, 'battery-full-charging-symbolic');
-        const textColorSourceDropDown = makeColorModeDropDown('text-color-source');
+        const textColorSourceDropDown = makeColorModeDropDown('charging-text-color-source');
         textColorSourceRow.add_suffix(textColorSourceDropDown);
         styleGroup.add(textColorSourceRow);
 
@@ -497,8 +500,8 @@ export default class BattConsumptionPreferences extends ExtensionPreferences {
             title: _('Custom Charging Text Color'),
             subtitle: _('Used only when Charging Text Color is set to Custom'),
         });
-        addIcon(customTextColorRow, 'font-x-generic-symbolic');
-        const customTextColorButton = makeColorButton('text-custom-color', _('Select Charging Text Color'));
+        addIcon(customTextColorRow, 'color-select-symbolic');
+        const customTextColorButton = makeColorButton('charging-text-custom-color', _('Select Charging Text Color'));
         customTextColorRow.add_suffix(customTextColorButton);
         styleGroup.add(customTextColorRow);
 
@@ -580,7 +583,7 @@ export default class BattConsumptionPreferences extends ExtensionPreferences {
             const iconGradientEnabled = settings.get_boolean('showcolored');
             const textGradientEnabled = settings.get_boolean('showcoloredtext');
             const useCustomIconColor = settings.get_string('charging-icon-color-source') === 'custom';
-            const useCustomTextColor = settings.get_string('text-color-source') === 'custom';
+            const useCustomTextColor = settings.get_string('charging-text-color-source') === 'custom';
             barOrientationRow.visible = !isCircle && !isStock;
             batteryWidthRow.visible = !isCircle && !isStock;
             batteryHeightRow.visible = !isCircle && !isStock;
@@ -612,7 +615,7 @@ export default class BattConsumptionPreferences extends ExtensionPreferences {
         settings.connect('changed::showcolored', updateDimensionVisibility);
         settings.connect('changed::showcoloredtext', updateDimensionVisibility);
         settings.connect('changed::charging-icon-color-source', updateDimensionVisibility);
-        settings.connect('changed::text-color-source', updateDimensionVisibility);
+        settings.connect('changed::charging-text-color-source', updateDimensionVisibility);
         updateDimensionVisibility();
 
         // Group: Auto-Hide Rules

--- a/extension/prefs.js
+++ b/extension/prefs.js
@@ -8,7 +8,7 @@ import GLib from 'gi://GLib';
 
 import { ExtensionPreferences, gettext as _ } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
-const BUILD_DATE = '2026-04-17T14:51:07.800Z';
+const BUILD_DATE = '2026-04-17T19:50:12.125Z';
 const CHANGELOG = `
 TEXT STROKE, DRY REFACTOR & CIRCULAR FONT REFRESH
 

--- a/extension/prefs.js
+++ b/extension/prefs.js
@@ -8,7 +8,7 @@ import GLib from 'gi://GLib';
 
 import { ExtensionPreferences, gettext as _ } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
-const BUILD_DATE = '2026-04-17T19:50:12.125Z';
+const BUILD_DATE = '2026-04-17T19:51:41.833Z';
 const CHANGELOG = `
 TEXT STROKE, DRY REFACTOR & CIRCULAR FONT REFRESH
 

--- a/extension/prefs.js
+++ b/extension/prefs.js
@@ -3,11 +3,12 @@
 import Gio from 'gi://Gio';
 import Gtk from 'gi://Gtk';
 import Adw from 'gi://Adw';
+import Gdk from 'gi://Gdk';
 import GLib from 'gi://GLib';
 
 import { ExtensionPreferences, gettext as _ } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
-const BUILD_DATE = '2026-04-15T17:41:06.350Z';
+const BUILD_DATE = '2026-04-17T13:58:16.559Z';
 const CHANGELOG = `
 TEXT STROKE, DRY REFACTOR & CIRCULAR FONT REFRESH
 
@@ -15,7 +16,7 @@ VISUAL POLISH & CODE QUALITY
 
 Stock Icon Mode: Added a new preference to use the native GNOME battery icon instead of the custom bar or circular indicator.
 
-Charging Color Tuning: Colored mode now falls back to the theme foreground while charging, avoiding misleading low-battery red/orange states.
+~~Charging Color Tuning: Colored mode now falls back to the theme foreground while charging, avoiding misleading low-battery red/orange states.~~
 
 Panel Sync: The stock icon path now respects the same panel visibility flow as the custom indicators.
 
@@ -29,7 +30,15 @@ Circular Font Size: Increased CIRCLE.FONT_SIZE_RATIO from 0.42 to 0.5 for better
 
 Bolt Stroke Fix: Fixed bolt SVG stroke not respecting the textStroke toggle in circular mode (with text displayed), ensuring stroke is disabled consistently when the setting is off.
 
-Preferences Cleanup: Added close-request handler to destroy Gtk.ListBox and Adw.ToastOverlay objects when the preferences window closes, fixing EGO-L-006 warning.`;
+Preferences Cleanup: Added close-request handler to destroy Gtk.ListBox and Adw.ToastOverlay objects when the preferences window closes, fixing EGO-L-006 warning.
+
+Charging Color Refactor: Removed the invalid implicit charging fallback and restored Gradient as the default color logic for both charging and discharging.
+
+Explicit Charging Overrides: Added Charging Icon Color and Charging Text Color modes with explicit Gradient, Theme Foreground, and Custom Color behavior.
+
+Defaults Update: Color Gradient Icon and Color Gradient Text now default to true.
+
+Preferences Polish: Cleaned up inconsistent preferences icons and replaced invalid symbolic icon names with working ones.`;
 
 export default class BattConsumptionPreferences extends ExtensionPreferences {
     _switchToNavigationSplitViews(window) {
@@ -149,6 +158,18 @@ export default class BattConsumptionPreferences extends ExtensionPreferences {
                 icon_name: iconName,
             });
             row.add_prefix(icon);
+        };
+        const rgbaFromHex = hex => {
+            const rgba = new Gdk.RGBA();
+            if (!rgba.parse(hex || '#ffffff')) rgba.parse('#ffffff');
+            return rgba;
+        };
+        const rgbaToHex = rgba => {
+            const toHex = value =>
+                Math.round(Math.max(0, Math.min(1, value)) * 255)
+                    .toString(16)
+                    .padStart(2, '0');
+            return `#${toHex(rgba.red)}${toHex(rgba.green)}${toHex(rgba.blue)}`;
         };
 
         const logBaseName = 'Batt Watt Power Monitor'.replace(/[^a-z0-9]/gi, '_').toLowerCase();
@@ -385,11 +406,45 @@ export default class BattConsumptionPreferences extends ExtensionPreferences {
         useStockIconRow.add_suffix(useStockIconSwitch);
         styleGroup.add(useStockIconRow);
 
+        const colorModeModel = Gtk.StringList.new([_('Gradient'), _('Theme Foreground'), _('Custom Color')]);
+        const colorModeMap = { gradient: 0, theme: 1, custom: 2 };
+        const colorModeValues = ['gradient', 'theme', 'custom'];
+        const makeColorModeDropDown = settingKey => {
+            const dropDown = new Gtk.DropDown({
+                valign: Gtk.Align.CENTER,
+                model: colorModeModel,
+            });
+            dropDown.set_selected(colorModeMap[settings.get_string(settingKey)] ?? 0);
+            dropDown.connect('notify::selected', widget => {
+                settings.set_string(settingKey, colorModeValues[widget.get_selected()] ?? 'gradient');
+            });
+            return dropDown;
+        };
+        const makeColorButton = (settingKey, title) => {
+            const dialog = new Gtk.ColorDialog({
+                modal: true,
+                title,
+                with_alpha: false,
+            });
+            const button = new Gtk.ColorDialogButton({
+                dialog,
+                valign: Gtk.Align.CENTER,
+            });
+            button.set_rgba(rgbaFromHex(settings.get_string(settingKey)));
+            button.connect('notify::rgba', widget => {
+                settings.set_string(settingKey, rgbaToHex(widget.get_rgba()));
+            });
+            settings.connect(`changed::${settingKey}`, () => {
+                button.set_rgba(rgbaFromHex(settings.get_string(settingKey)));
+            });
+            return button;
+        };
+
         const showColoredRow = new Adw.ActionRow({
-            title: _('Colored Ring'),
-            subtitle: _('Use colors to indicate charge level'),
+            title: _('Color Gradient Icon'),
+            subtitle: _('Apply the normal red-to-green gradient to the icon'),
         });
-        addIcon(showColoredRow, 'applications-graphics-symbolic');
+        addIcon(showColoredRow, 'image-x-generic-symbolic');
         const showColoredSwitch = new Gtk.Switch({
             active: settings.get_boolean('showcolored'),
             valign: Gtk.Align.CENTER,
@@ -397,6 +452,55 @@ export default class BattConsumptionPreferences extends ExtensionPreferences {
         settings.bind('showcolored', showColoredSwitch, 'active', Gio.SettingsBindFlags.DEFAULT);
         showColoredRow.add_suffix(showColoredSwitch);
         styleGroup.add(showColoredRow);
+
+        const chargingIconColorRow = new Adw.ActionRow({
+            title: _('Charging Icon Color'),
+            subtitle: _('Choose how the icon is colored while charging'),
+        });
+        addIcon(chargingIconColorRow, 'battery-full-charging-symbolic');
+        const chargingIconColorDropDown = makeColorModeDropDown('charging-icon-color-source');
+        chargingIconColorRow.add_suffix(chargingIconColorDropDown);
+        styleGroup.add(chargingIconColorRow);
+
+        const customIconColorRow = new Adw.ActionRow({
+            title: _('Custom Charging Icon Color'),
+            subtitle: _('Used only when Charging Icon Color is set to Custom'),
+        });
+        addIcon(customIconColorRow, 'battery-full-charging-symbolic');
+        const customIconColorButton = makeColorButton('icon-custom-color', _('Select Charging Icon Color'));
+        customIconColorRow.add_suffix(customIconColorButton);
+        styleGroup.add(customIconColorRow);
+
+        const showColoredTextRow = new Adw.ActionRow({
+            title: _('Color Gradient Text'),
+            subtitle: _('Apply the normal red-to-green gradient to text'),
+        });
+        addIcon(showColoredTextRow, 'font-x-generic-symbolic');
+        const showColoredTextSwitch = new Gtk.Switch({
+            active: settings.get_boolean('showcoloredtext'),
+            valign: Gtk.Align.CENTER,
+        });
+        settings.bind('showcoloredtext', showColoredTextSwitch, 'active', Gio.SettingsBindFlags.DEFAULT);
+        showColoredTextRow.add_suffix(showColoredTextSwitch);
+        styleGroup.add(showColoredTextRow);
+
+        const textColorSourceRow = new Adw.ActionRow({
+            title: _('Charging Text Color'),
+            subtitle: _('Choose the color used by text while the battery is charging'),
+        });
+        addIcon(textColorSourceRow, 'battery-full-charging-symbolic');
+        const textColorSourceDropDown = makeColorModeDropDown('text-color-source');
+        textColorSourceRow.add_suffix(textColorSourceDropDown);
+        styleGroup.add(textColorSourceRow);
+
+        const customTextColorRow = new Adw.ActionRow({
+            title: _('Custom Charging Text Color'),
+            subtitle: _('Used only when Charging Text Color is set to Custom'),
+        });
+        addIcon(customTextColorRow, 'font-x-generic-symbolic');
+        const customTextColorButton = makeColorButton('text-custom-color', _('Select Charging Text Color'));
+        customTextColorRow.add_suffix(customTextColorButton);
+        styleGroup.add(customTextColorRow);
 
         const textStrokeRow = new Adw.ActionRow({
             title: _('Text Stroke'),
@@ -473,14 +577,42 @@ export default class BattConsumptionPreferences extends ExtensionPreferences {
         const updateDimensionVisibility = () => {
             const isCircle = settings.get_boolean('usecircleindicator');
             const isStock = settings.get_boolean('use-stock-icon');
+            const iconGradientEnabled = settings.get_boolean('showcolored');
+            const textGradientEnabled = settings.get_boolean('showcoloredtext');
+            const useCustomIconColor = settings.get_string('charging-icon-color-source') === 'custom';
+            const useCustomTextColor = settings.get_string('text-color-source') === 'custom';
             barOrientationRow.visible = !isCircle && !isStock;
             batteryWidthRow.visible = !isCircle && !isStock;
             batteryHeightRow.visible = !isCircle && !isStock;
             circleSizeRow.visible = isCircle && !isStock;
             circleIndicatorRow.sensitive = !isStock;
+            chargingIconColorRow.visible = iconGradientEnabled;
+            customIconColorRow.visible = iconGradientEnabled;
+            textColorSourceRow.visible = textGradientEnabled;
+            customTextColorRow.visible = textGradientEnabled;
+            customIconColorButton.set_sensitive(iconGradientEnabled && useCustomIconColor);
+            customTextColorButton.set_sensitive(textGradientEnabled && useCustomTextColor);
+            const iconDisabledTooltip = !iconGradientEnabled
+                ? _('Disabled while Color Gradient Icon is off.')
+                : _('Disabled while Charging Icon Color is not set to Custom.');
+            const textDisabledTooltip = !textGradientEnabled
+                ? _('Disabled while Color Gradient Text is off.')
+                : _('Disabled while Charging Text Color is not set to Custom.');
+            customIconColorRow.set_tooltip_text(useCustomIconColor && iconGradientEnabled ? null : iconDisabledTooltip);
+            customIconColorButton.set_tooltip_text(
+                useCustomIconColor && iconGradientEnabled ? null : iconDisabledTooltip,
+            );
+            customTextColorRow.set_tooltip_text(useCustomTextColor && textGradientEnabled ? null : textDisabledTooltip);
+            customTextColorButton.set_tooltip_text(
+                useCustomTextColor && textGradientEnabled ? null : textDisabledTooltip,
+            );
         };
         settings.connect('changed::usecircleindicator', updateDimensionVisibility);
         settings.connect('changed::use-stock-icon', updateDimensionVisibility);
+        settings.connect('changed::showcolored', updateDimensionVisibility);
+        settings.connect('changed::showcoloredtext', updateDimensionVisibility);
+        settings.connect('changed::charging-icon-color-source', updateDimensionVisibility);
+        settings.connect('changed::text-color-source', updateDimensionVisibility);
         updateDimensionVisibility();
 
         // Group: Auto-Hide Rules

--- a/extension/schemas/org.gnome.shell.extensions.batt-watt-power-monitor.gschema.xml
+++ b/extension/schemas/org.gnome.shell.extensions.batt-watt-power-monitor.gschema.xml
@@ -81,9 +81,34 @@
       <description>If enabled, displays wattage like 15.75W. If disabled, displays 16W.</description>
     </key>
     <key type="b" name="showcolored">
-      <default>false</default>
+      <default>true</default>
       <summary>Show colored indicator</summary>
-      <description>Enable colored ring/text for the circular indicator. Disable to force monochrome (loses the color).</description>
+      <description>Enable the charge-level gradient for the battery icon. Disable to force monochrome themed rendering.</description>
+    </key>
+    <key type="b" name="showcoloredtext">
+      <default>true</default>
+      <summary>Show gradient text</summary>
+      <description>Enable the charge-level gradient for panel text. Disable to force monochrome themed rendering.</description>
+    </key>
+    <key type="s" name="charging-icon-color-source">
+      <default>'gradient'</default>
+      <summary>Charging icon color source</summary>
+      <description>Controls which color mode is used for the icon while charging.</description>
+    </key>
+    <key type="s" name="icon-custom-color">
+      <default>'#ffffff'</default>
+      <summary>Custom charging icon color</summary>
+      <description>Custom hex color used for the icon while charging when the custom charging color option is selected.</description>
+    </key>
+    <key type="s" name="text-color-source">
+      <default>'gradient'</default>
+      <summary>Charging text color source</summary>
+      <description>Controls which color mode is used for text while charging.</description>
+    </key>
+    <key type="s" name="text-custom-color">
+      <default>'#ffffff'</default>
+      <summary>Custom charging text color</summary>
+      <description>Custom hex color used for text while charging when the custom charging color option is selected.</description>
     </key>
     <key type="b" name="textstroke">
       <default>true</default>

--- a/extension/schemas/org.gnome.shell.extensions.batt-watt-power-monitor.gschema.xml
+++ b/extension/schemas/org.gnome.shell.extensions.batt-watt-power-monitor.gschema.xml
@@ -91,21 +91,31 @@
       <description>Enable the charge-level gradient for panel text. Disable to force monochrome themed rendering.</description>
     </key>
     <key type="s" name="charging-icon-color-source">
+      <choices>
+        <choice value='gradient'/>
+        <choice value='theme'/>
+        <choice value='custom'/>
+      </choices>
       <default>'gradient'</default>
       <summary>Charging icon color source</summary>
       <description>Controls which color mode is used for the icon while charging.</description>
     </key>
-    <key type="s" name="icon-custom-color">
+    <key type="s" name="charging-icon-custom-color">
       <default>'#ffffff'</default>
       <summary>Custom charging icon color</summary>
       <description>Custom hex color used for the icon while charging when the custom charging color option is selected.</description>
     </key>
-    <key type="s" name="text-color-source">
+    <key type="s" name="charging-text-color-source">
+      <choices>
+        <choice value='gradient'/>
+        <choice value='theme'/>
+        <choice value='custom'/>
+      </choices>
       <default>'gradient'</default>
       <summary>Charging text color source</summary>
       <description>Controls which color mode is used for text while charging.</description>
     </key>
-    <key type="s" name="text-custom-color">
+    <key type="s" name="charging-text-custom-color">
       <default>'#ffffff'</default>
       <summary>Custom charging text color</summary>
       <description>Custom hex color used for text while charging when the custom charging color option is selected.</description>


### PR DESCRIPTION
## Summary
- restore `Gradient` as the default charging and discharging color behavior for both icon and text
- replace the implicit charging fallback logic with explicit charging overrides for icon and text: `Gradient`, `Theme Foreground`, and `Custom Color`
- default `Color Gradient Icon` and `Color Gradient Text` to `true`, clean up invalid/inconsistent preference icons, and align README/changelog docs with the refactor

## Notes
- validated locally with `./build.sh`
- confirmed the extension behaves correctly after the refactor
- published from the shared repo via MSI shell because non-interactive SSH on HP was not using the working interactive zsh auth path


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit charging icon and text color override modes with Gradient, Theme Foreground, and Custom Color options.
  * Enabled color gradient defaults for icon and text rendering.

* **Bug Fixes**
  * Removed invalid implicit charging fallback.

* **Documentation**
  * Updated changelog and README with new charging color configuration details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->